### PR TITLE
Fix: broken badges in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 # OpenTTD's Survey website
 
 [![GitHub License](https://img.shields.io/github/license/OpenTTD/survey-web)](https://github.com/OpenTTD/survey-web/blob/main/LICENSE)
-[![GitHub Tag](https://img.shields.io/github/v/tag/OpenTTD/survey-web?include_prereleases&label=stable)](https://github.com/OpenTTD/survey-web/releases)
-[![GitHub commits since latest release](https://img.shields.io/github/commits-since/OpenTTD/survey-web/latest/main)](https://github.com/OpenTTD/survey-web/commits/main)
 
 This is the [website](https://survey.openttd.org) to show the results of the survey analysis and the information and privacy statement of the participation.
 


### PR DESCRIPTION
This repository will never see an actual tag or release, as main is directly deployed to production.