### PR TITLE
Add: collapse all entries < 0.1% into an "(other)" entry

### DIFF
--- a/_layouts/summaries.html
+++ b/_layouts/summaries.html
@@ -36,6 +36,10 @@ layout: default
                 Be mindful that these numbers are only based on those people willing to send us survey results.
                 It might not be representative of the entire OpenTTD player base.
             </p>
+
+            <p>
+                Entries listed as "(other)" are the collection of all values lower than 0.1% of the total.
+            </p>
         </div>
     </div>
 

--- a/analysis/__main__.py
+++ b/analysis/__main__.py
@@ -229,10 +229,21 @@ def main():
             if path.startswith("game.settings.display_opt.") or path.startswith("game.settings.extra_display_opt."):
                 data["false"] = version_summary["summary"]["seconds"] - data["true"]
 
-            # Check if it adds up to the total; if not, it is (most likely) an OS specific setting.
             total = sum(data.values())
+
+            # Check if it adds up to the total; if not, it is (most likely) an OS specific setting.
             if path != "summary" and total != version_summary["summary"]["seconds"]:
                 data["(not reported)"] = version_summary["summary"]["seconds"] - total
+
+            # Collapse entries below 0.1% to a single (other) entry, and not true/false.
+            if path != "summary":
+                collapse = []
+                for key, value in data.items():
+                    if value / total < 0.001 and key not in ("true", "false", "(not reported)"):
+                        collapse.append(key)
+                for key in collapse:
+                    data["(other)"] += data[key]
+                    del data[key]
 
             # Sort the data based on the value.
             summary[version][path] = dict(sorted(data.items(), key=lambda item: item[1], reverse=True))


### PR DESCRIPTION
For string-based settings like currency prefix/suffix, people can fill in what-ever they like. This ends up as a long list of all kind of strings, most used only in very rare cases.