### PR TITLE
Fix: parse Windows versions correctly, even if it is "SP1, v.721"

### DIFF
--- a/analysis/__main__.py
+++ b/analysis/__main__.py
@@ -146,7 +146,7 @@ def summarize_setting(summary, version, seconds, path, data):
 
     if path == "info.os.os":
         if data.startswith("Windows"):
-            major, minor, buildnumber = data.split(" ", 1)[1].split(".")
+            major, minor, buildnumber = data.split(" ")[1].split(".")
             os_version = WINDOWS_BUILD_NUMBER_TO_NAME.get(f"{major}.{minor}", data)
             if major == "10" and buildnumber.isdigit() and int(buildnumber) >= 22000:
                 os_version = WINDOWS_BUILD_NUMBER_TO_NAME.get(f"{major}.{minor}.22000", os_version)


### PR DESCRIPTION
A version can be `Windows 6.1.7601 (Service Pack 1, v.721)`.
We never assumed the `v.721` could have a dot. It also never happened. This was the first time.

Nevertheless, just take the middle part and assume that contains the version. No need to look after the second space.