### PR TITLE
Fix: [CI] Use unprivileged env to build website

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,50 @@
+name: Build
+
+on:
+  push:
+    branches:
+    - main
+  pull_request:
+    branches:
+    - main
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    name: Build
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+      with:
+        ref: ${{ github.event.pull_request.head.sha || github.ref }}
+        fetch-depth: 0
+
+    - name: Set up Ruby 3.3
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: '3.3'
+        bundler-cache: true
+
+    - name: Build
+      run: |
+        JEKYLL_ENV=production bundle exec jekyll build --strict_front_matter
+
+    - name: Prepare branch name
+      run: |
+        mkdir branch
+        echo "${{ github.event_name == 'push' && github.ref_name || format('pr/{0}', github.event.pull_request.number) }}" > ./branch/name
+
+    - name: Upload artifacts
+      uses: actions/upload-artifact@v6
+      with:
+        name: payload
+        path: |
+          _site
+          branch
+        retention-days: 1

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,53 +1,59 @@
 name: Publish
 
 on:
-  push:
-    branches:
-    - main
-  pull_request_target:
-    branches:
-    - main
-
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+  workflow_run:
+    workflows:
+    - Build
+    types:
+    - completed
 
 jobs:
   publish:
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      deployments: write
 
     name: Publish to Cloudflare Pages
 
-    environment:
-      name: ${{ github.event_name == 'push' && 'Production' || 'Preview' }}
-      url: ${{ steps.pages.outputs.url }}
+    if: github.event.workflow_run.conclusion == 'success'
 
     steps:
-    - name: Checkout
-      uses: actions/checkout@v4
-      with:
-        ref: ${{ github.event.pull_request.head.sha || github.ref }}
-        fetch-depth: 0
-
-    - name: Set up Ruby 3.3
-      uses: ruby/setup-ruby@v1
-      with:
-        ruby-version: '3.3'
-        bundler-cache: true
-
-    - name: Build
+    - name: Create deployment
+      id: deployment
       run: |
-        JEKYLL_ENV=production bundle exec jekyll build --strict_front_matter
+        curl -L \
+        -X POST \
+        -H "Accept: application/vnd.github+json" \
+        -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+        -H "X-GitHub-Api-Version: 2026-03-10" \
+        https://api.github.com/repos/${{ github.repository }}/deployments \
+        -d '{"ref":"${{ github.event.workflow_run.head_sha }}","environment":"${{ github.event.workflow_run.event == 'push' && 'Production' || 'Preview' }}","required_contexts":[]}' \
+        | jq --raw-output0 '"url=\(.statuses_url)"' >> $GITHUB_OUTPUT
+
+    - name: Download artifacts
+      uses: actions/download-artifact@v8
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        run-id: ${{github.event.workflow_run.id }}
+
+    - name: Get branch name
+      id: branch
+      run: |
+        echo "name=$(cat branch/name)" >> $GITHUB_OUTPUT
 
     - name: Publish to Cloudflare Pages
-      uses: cloudflare/pages-action@v1
+      uses: cloudflare/wrangler-action@v3
       id: pages
       with:
         apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
         accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-        projectName: ${{ vars.CLOUDFLARE_PROJECT_NAME }}
-        directory: _site
-        branch: ${{ github.event_name == 'push' && github.ref_name || format('pr/{0}', github.event.pull_request.number) }}
+        command: pages deploy _site --project-name=${{ vars.CLOUDFLARE_PROJECT_NAME }} --branch ${{ steps.branch.outputs.name }}
+
+    - name: Update deployment
+      if: always()
+      run: |
+        curl -L \
+        -X POST \
+        -H "Accept: application/vnd.github+json" \
+        -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+        -H "X-GitHub-Api-Version: 2026-03-10" \
+        ${{ steps.deployment.outputs.url }} \
+        -d '{"state":"${{ job.status }}","log_url":"${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}","environment_url":"${{ steps.pages.outputs.pages-deployment-alias-url }}","auto_inactive":false}'


### PR DESCRIPTION
There is some nastiness going around on GitHub, where people create a PR which tries to exfil repo secrets. And publish.yml is potentially vulnerable because it's using pull_request_target.

Split build and publish, so build workflow is always done in an unprivileged env.
Build result is then uploaded as artifacts and publish workflow (using workflow_run) can retrieve it to do the actual upload to cloudflare.

Also migrated from cloudflare/pages-action (deprecated) to cloudflare/wrangler-action.

Not really tested, but I did the same thing as for [OpenTTD/website](https://github.com/OpenTTD/website).