### PR TITLE
Fix 025e1cb: Use correct output variable

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -56,4 +56,4 @@ jobs:
         -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
         -H "X-GitHub-Api-Version: 2026-03-10" \
         ${{ steps.deployment.outputs.url }} \
-        -d '{"state":"${{ job.status }}","log_url":"${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}","environment_url":"${{ steps.pages.outputs.pages-deployment-alias-url }}","auto_inactive":false}'
+        -d '{"state":"${{ job.status }}","log_url":"${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}","environment_url":"${{ steps.pages.outputs.pages-deployment-alias-url || steps.pages.outputs.deployment-url }}","auto_inactive":false}'


### PR DESCRIPTION
`pages-deployment-alias-url` is filled only for PRs, while `deployment-url` exists in all cases.

Non-PR:
<img width="642" height="61" alt="image" src="https://github.com/user-attachments/assets/ca3c6dff-0e14-4f23-af0d-7ba155a52746" />

PR:
<img width="642" height="75" alt="image" src="https://github.com/user-attachments/assets/2a9f6e6a-c556-48c7-a07e-31eaac0c9bc5" />
